### PR TITLE
make sure GraphQLDescription is included

### DIFF
--- a/src/main/kotlin/org/misarch/catalog/graphql/input/CategoricalCategoryCharacteristicInput.kt
+++ b/src/main/kotlin/org/misarch/catalog/graphql/input/CategoricalCategoryCharacteristicInput.kt
@@ -4,8 +4,8 @@ import com.expediagroup.graphql.generator.annotations.GraphQLDescription
 
 @GraphQLDescription("Input to create a CategoricalCategoryCharacteristic for a Category")
 open class CategoricalCategoryCharacteristicInput(
-    @GraphQLDescription("The name of the CategoricalCategoryCharacteristic")
+    @property:GraphQLDescription("The name of the CategoricalCategoryCharacteristic")
     val name: String,
-    @GraphQLDescription("The description of the CategoricalCategoryCharacteristic")
+    @property:GraphQLDescription("The description of the CategoricalCategoryCharacteristic")
     val description: String
 )

--- a/src/main/kotlin/org/misarch/catalog/graphql/input/CategoricalCategoryCharacteristicValueInput.kt
+++ b/src/main/kotlin/org/misarch/catalog/graphql/input/CategoricalCategoryCharacteristicValueInput.kt
@@ -5,8 +5,8 @@ import com.expediagroup.graphql.generator.scalars.ID
 
 @GraphQLDescription("Input for creating a CategoricalCategoryCharacteristicValue.")
 class CategoricalCategoryCharacteristicValueInput(
-    @GraphQLDescription("The value of the CategoricalCategoryCharacteristicValue.")
+    @property:GraphQLDescription("The value of the CategoricalCategoryCharacteristicValue.")
     val value: String,
-    @GraphQLDescription("The id of the CategoryCharacteristic.")
+    @property:GraphQLDescription("The id of the CategoryCharacteristic.")
     val characteristicId: ID
 )

--- a/src/main/kotlin/org/misarch/catalog/graphql/input/CreateCategoricalCategoryCharacteristicInput.kt
+++ b/src/main/kotlin/org/misarch/catalog/graphql/input/CreateCategoricalCategoryCharacteristicInput.kt
@@ -7,6 +7,6 @@ import com.expediagroup.graphql.generator.scalars.ID
 class CreateCategoricalCategoryCharacteristicInput(
     name: String,
     description: String,
-    @GraphQLDescription("The Category that the CategoricalCategoryCharacteristicI belongs to")
+    @property:GraphQLDescription("The Category that the CategoricalCategoryCharacteristicI belongs to")
     val categoryId: ID
 ) : CategoricalCategoryCharacteristicInput(name, description)

--- a/src/main/kotlin/org/misarch/catalog/graphql/input/CreateCategoryInput.kt
+++ b/src/main/kotlin/org/misarch/catalog/graphql/input/CreateCategoryInput.kt
@@ -4,12 +4,12 @@ import com.expediagroup.graphql.generator.annotations.GraphQLDescription
 
 @GraphQLDescription("Input for the createCategory mutation")
 class CreateCategoryInput(
-    @GraphQLDescription("The name of the Category")
+    @property:GraphQLDescription("The name of the Category")
     val name: String,
-    @GraphQLDescription("The description of the Category")
+    @property:GraphQLDescription("The description of the Category")
     val description: String,
-    @GraphQLDescription("The CategoricalCategoryCharacteristics of the Category")
+    @property:GraphQLDescription("The CategoricalCategoryCharacteristics of the Category")
     val categoricalCharacteristics: List<CategoricalCategoryCharacteristicInput>,
-    @GraphQLDescription("The NumericalCategoryCharacteristics of the Category")
+    @property:GraphQLDescription("The NumericalCategoryCharacteristics of the Category")
     val numericalCharacteristics: List<NumericalCategoryCharacteristicInput>,
 )

--- a/src/main/kotlin/org/misarch/catalog/graphql/input/CreateNumericalCategoryCharacteristicInput.kt
+++ b/src/main/kotlin/org/misarch/catalog/graphql/input/CreateNumericalCategoryCharacteristicInput.kt
@@ -8,6 +8,6 @@ class CreateNumericalCategoryCharacteristicInput(
     name: String,
     description: String,
     unit: String,
-    @GraphQLDescription("The Category that the NumericalCategoryCharacteristic belongs to")
+    @property:GraphQLDescription("The Category that the NumericalCategoryCharacteristic belongs to")
     val categoryId: ID
 ) : NumericalCategoryCharacteristicInput(name, description, unit)

--- a/src/main/kotlin/org/misarch/catalog/graphql/input/CreateProductInput.kt
+++ b/src/main/kotlin/org/misarch/catalog/graphql/input/CreateProductInput.kt
@@ -5,12 +5,12 @@ import com.expediagroup.graphql.generator.scalars.ID
 
 @GraphQLDescription("Input for the createProduct mutation")
 class CreateProductInput(
-    @GraphQLDescription("An internal name to identify the Product, not visible to customers.")
+    @property:GraphQLDescription("An internal name to identify the Product, not visible to customers.")
     val internalName: String,
-    @GraphQLDescription("If true, the Product is visible to customers.")
+    @property:GraphQLDescription("If true, the Product is visible to customers.")
     val isPubliclyVisible: Boolean,
-    @GraphQLDescription("The default ProductVariant of the Product.")
+    @property:GraphQLDescription("The default ProductVariant of the Product.")
     val defaultVariant: ProductVariantInput,
-    @GraphQLDescription("The Categories this product is associated with.")
+    @property:GraphQLDescription("The Categories this product is associated with.")
     val categoryIds: List<ID>,
 )

--- a/src/main/kotlin/org/misarch/catalog/graphql/input/CreateProductVariantInput.kt
+++ b/src/main/kotlin/org/misarch/catalog/graphql/input/CreateProductVariantInput.kt
@@ -5,7 +5,7 @@ import com.expediagroup.graphql.generator.scalars.ID
 
 @GraphQLDescription("Input for the createProductVariant mutation")
 class CreateProductVariantInput(
-    @GraphQLDescription("The id of the Product this ProductVariant belongs to.")
+    @property:GraphQLDescription("The id of the Product this ProductVariant belongs to.")
     val productId: ID,
     isPubliclyVisible: Boolean,
     initialVersion: ProductVariantVersionInput

--- a/src/main/kotlin/org/misarch/catalog/graphql/input/CreateProductVariantVersionInput.kt
+++ b/src/main/kotlin/org/misarch/catalog/graphql/input/CreateProductVariantVersionInput.kt
@@ -5,6 +5,7 @@ import com.expediagroup.graphql.generator.scalars.ID
 
 @GraphQLDescription("Input for the createProductVariantVersion mutation")
 class CreateProductVariantVersionInput(
+    @property:GraphQLDescription("The id of the ProductVariant this ProductVariantVersion belongs to.")
     val productVariantId: ID,
     name: String,
     description: String,

--- a/src/main/kotlin/org/misarch/catalog/graphql/input/NumericalCategoryCharacteristicInput.kt
+++ b/src/main/kotlin/org/misarch/catalog/graphql/input/NumericalCategoryCharacteristicInput.kt
@@ -4,10 +4,10 @@ import com.expediagroup.graphql.generator.annotations.GraphQLDescription
 
 @GraphQLDescription("Input to create a characteristic whose values have arithmetic meaning, i.e. '8GB'")
 open class NumericalCategoryCharacteristicInput(
-    @GraphQLDescription("The name of the NumericalCategoryCharacteristic")
+    @property:GraphQLDescription("The name of the NumericalCategoryCharacteristic")
     val name: String,
-    @GraphQLDescription("The description of the NumericalCategoryCharacteristic")
+    @property:GraphQLDescription("The description of the NumericalCategoryCharacteristic")
     val description: String,
-    @GraphQLDescription("The unit of the NumericalCategoryCharacteristic")
+    @property:GraphQLDescription("The unit of the NumericalCategoryCharacteristic")
     val unit: String,
 )

--- a/src/main/kotlin/org/misarch/catalog/graphql/input/NumericalCategoryCharacteristicValueInput.kt
+++ b/src/main/kotlin/org/misarch/catalog/graphql/input/NumericalCategoryCharacteristicValueInput.kt
@@ -5,8 +5,8 @@ import com.expediagroup.graphql.generator.scalars.ID
 
 @GraphQLDescription("Input for creating a NumericalCategoryCharacteristicValue.")
 class NumericalCategoryCharacteristicValueInput(
-    @GraphQLDescription("The value of the NumericalCategoryCharacteristicValue.")
+    @property:GraphQLDescription("The value of the NumericalCategoryCharacteristicValue.")
     val value: Double,
-    @GraphQLDescription("The id of the CategoryCharacteristic.")
+    @property:GraphQLDescription("The id of the CategoryCharacteristic.")
     val characteristicId: ID
 )

--- a/src/main/kotlin/org/misarch/catalog/graphql/input/ProductVariantInput.kt
+++ b/src/main/kotlin/org/misarch/catalog/graphql/input/ProductVariantInput.kt
@@ -4,8 +4,8 @@ import com.expediagroup.graphql.generator.annotations.GraphQLDescription
 
 @GraphQLDescription("Input for creating a product variant")
 open class ProductVariantInput(
-    @GraphQLDescription("If true, the ProductVariant is visible to customers.")
+    @property:GraphQLDescription("If true, the ProductVariant is visible to customers.")
     val isPubliclyVisible: Boolean,
-    @GraphQLDescription("The initial ProductVariantVersion of the ProductVariant.")
+    @property:GraphQLDescription("The initial ProductVariantVersion of the ProductVariant.")
     val initialVersion: ProductVariantVersionInput
 )

--- a/src/main/kotlin/org/misarch/catalog/graphql/input/ProductVariantVersionInput.kt
+++ b/src/main/kotlin/org/misarch/catalog/graphql/input/ProductVariantVersionInput.kt
@@ -4,16 +4,16 @@ import com.expediagroup.graphql.generator.annotations.GraphQLDescription
 
 @GraphQLDescription("Input for creating a ProductVariantVersion.")
 open class ProductVariantVersionInput(
-    @GraphQLDescription("The name of the ProductVariant.")
+    @property:GraphQLDescription("The name of the ProductVariant.")
     val name: String,
-    @GraphQLDescription("The description of the ProductVariant.")
+    @property:GraphQLDescription("The description of the ProductVariant.")
     val description: String,
-    @GraphQLDescription("The retail price of the ProductVariant.")
+    @property:GraphQLDescription("The retail price of the ProductVariant.")
     val retailPrice: Int,
-    @GraphQLDescription("The amount of days for which an instance of the ProductVariant can be returned after purchase")
+    @property:GraphQLDescription("The amount of days for which an instance of the ProductVariant can be returned after purchase")
     val canBeReturnedForDays: Double? = null,
-    @GraphQLDescription("The CategoricalCategoryCharacteristicValues of the ProductVariant, must be compatible with the Categories of the associated Product.")
+    @property:GraphQLDescription("The CategoricalCategoryCharacteristicValues of the ProductVariant, must be compatible with the Categories of the associated Product.")
     val categoricalCharacteristicValues: List<CategoricalCategoryCharacteristicValueInput>,
-    @GraphQLDescription("The NumericalCategoryCharacteristicValues of the ProductVariant, must be compatible with the Categories of the associated Product.")
+    @property:GraphQLDescription("The NumericalCategoryCharacteristicValues of the ProductVariant, must be compatible with the Categories of the associated Product.")
     val numericalCharacteristicValues: List<NumericalCategoryCharacteristicValueInput>
 )

--- a/src/main/kotlin/org/misarch/catalog/graphql/model/CategoricalCategoryCharacteristicValue.kt
+++ b/src/main/kotlin/org/misarch/catalog/graphql/model/CategoricalCategoryCharacteristicValue.kt
@@ -6,6 +6,6 @@ import java.util.*
 @GraphQLDescription("A possible value for a categorical characteristic.")
 class CategoricalCategoryCharacteristicValue(
     characteristicId: UUID,
-    @GraphQLDescription("The value of the characteristic.")
+    @property:GraphQLDescription("The value of the characteristic.")
     val value: String,
 ) : CategoryCharacteristicValue(characteristicId)

--- a/src/main/kotlin/org/misarch/catalog/graphql/model/Category.kt
+++ b/src/main/kotlin/org/misarch/catalog/graphql/model/Category.kt
@@ -17,9 +17,9 @@ import java.util.*
 @GraphQLDescription("A category")
 class Category(
     id: UUID,
-    @GraphQLDescription("The name of the category.")
+    @property:GraphQLDescription("The name of the category.")
     val name: String,
-    @GraphQLDescription("The description of the category.")
+    @property:GraphQLDescription("The description of the category.")
     val description: String,
 ) : Node(id) {
 

--- a/src/main/kotlin/org/misarch/catalog/graphql/model/CategoryCharacteristic.kt
+++ b/src/main/kotlin/org/misarch/catalog/graphql/model/CategoryCharacteristic.kt
@@ -9,9 +9,9 @@ import java.util.concurrent.CompletableFuture
 @GraphQLDescription("A characteristic of a Category.")
 abstract class CategoryCharacteristic(
     id: UUID,
-    @GraphQLDescription("The name of the CategoryCharacteristic.")
+    @property:GraphQLDescription("The name of the CategoryCharacteristic.")
     val name: String,
-    @GraphQLDescription("The description of the CategoryCharacteristic.")
+    @property:GraphQLDescription("The description of the CategoryCharacteristic.")
     val description: String, private val categoryId: UUID
 ) : Node(id) {
 

--- a/src/main/kotlin/org/misarch/catalog/graphql/model/Node.kt
+++ b/src/main/kotlin/org/misarch/catalog/graphql/model/Node.kt
@@ -9,6 +9,7 @@ abstract class Node(
     internal val id: UUID
 ) {
 
+    @GraphQLDescription("The ID of the node.")
     fun id(): ID {
         return ID(id.toString())
     }

--- a/src/main/kotlin/org/misarch/catalog/graphql/model/NumericalCategoryCharacteristic.kt
+++ b/src/main/kotlin/org/misarch/catalog/graphql/model/NumericalCategoryCharacteristic.kt
@@ -9,6 +9,6 @@ class NumericalCategoryCharacteristic(
     name: String,
     description: String,
     categoryId: UUID,
-    @GraphQLDescription("The unit of the NumericalCategoryCharacteristic.")
+    @property:GraphQLDescription("The unit of the NumericalCategoryCharacteristic.")
     val unit: String,
 ) : CategoryCharacteristic(id, name, description, categoryId)

--- a/src/main/kotlin/org/misarch/catalog/graphql/model/NumericalCategoryCharacteristicValue.kt
+++ b/src/main/kotlin/org/misarch/catalog/graphql/model/NumericalCategoryCharacteristicValue.kt
@@ -6,6 +6,6 @@ import java.util.*
 @GraphQLDescription("A numerical value of a NumericalCategoryCharacteristic.")
 class NumericalCategoryCharacteristicValue(
     characteristicId: UUID,
-    @GraphQLDescription("The value of the NumericalCategoryCharacteristic.")
+    @property:GraphQLDescription("The value of the NumericalCategoryCharacteristic.")
     val value: Double,
 ) : CategoryCharacteristicValue(characteristicId)

--- a/src/main/kotlin/org/misarch/catalog/graphql/model/Product.kt
+++ b/src/main/kotlin/org/misarch/catalog/graphql/model/Product.kt
@@ -20,9 +20,9 @@ import java.util.concurrent.CompletableFuture
 @GraphQLDescription("A product.")
 class Product(
     id: UUID,
-    @GraphQLDescription("An internal name to identify the Product, not visible to customers.")
+    @property:GraphQLDescription("An internal name to identify the Product, not visible to customers.")
     val internalName: String,
-    @GraphQLDescription("If true, the Product is visible to customers.")
+    @property:GraphQLDescription("If true, the Product is visible to customers.")
     val isPubliclyVisible: Boolean, private val defaultVariantId: UUID
 ) : Node(id) {
 

--- a/src/main/kotlin/org/misarch/catalog/graphql/model/ProductVariant.kt
+++ b/src/main/kotlin/org/misarch/catalog/graphql/model/ProductVariant.kt
@@ -16,7 +16,7 @@ import java.util.concurrent.CompletableFuture
 @GraphQLDescription("A variant of a Product.")
 class ProductVariant(
     id: UUID,
-    @GraphQLDescription("If true, the ProductVariant is visible to customers.")
+    @property:GraphQLDescription("If true, the ProductVariant is visible to customers.")
     val isPubliclyVisible: Boolean, private val productId: UUID, private val currentVersion: UUID
 ) : Node(id) {
 

--- a/src/main/kotlin/org/misarch/catalog/graphql/model/ProductVariantVersion.kt
+++ b/src/main/kotlin/org/misarch/catalog/graphql/model/ProductVariantVersion.kt
@@ -16,17 +16,17 @@ import java.util.concurrent.CompletableFuture
 @GraphQLDescription("A version of a ProductVariant.")
 class ProductVariantVersion(
     id: UUID,
-    @GraphQLDescription("The name of the ProductVariantVersion.")
+    @property:GraphQLDescription("The name of the ProductVariantVersion.")
     val name: String,
-    @GraphQLDescription("The description of the ProductVariantVersion.")
+    @property:GraphQLDescription("The description of the ProductVariantVersion.")
     val description: String,
-    @GraphQLDescription("The version of the ProductVariantVersion.")
+    @property:GraphQLDescription("The version of the ProductVariantVersion.")
     val version: Int,
-    @GraphQLDescription("The retail price of the ProductVariantVersion.")
+    @property:GraphQLDescription("The retail price of the ProductVariantVersion.")
     val retailPrice: Int,
-    @GraphQLDescription("The date when the ProductVariantVersion version was created.")
+    @property:GraphQLDescription("The date when the ProductVariantVersion version was created.")
     val createdAt: OffsetDateTime,
-    @GraphQLDescription("The amount of days for which an instance of the ProductVariantVersion can be returned after purchase")
+    @property:GraphQLDescription("The amount of days for which an instance of the ProductVariantVersion can be returned after purchase")
     val canBeReturnedForDays: Double?,
     private val productVariantId: UUID
 ) : Node(id) {

--- a/src/main/kotlin/org/misarch/catalog/graphql/model/connection/base/BaseOrder.kt
+++ b/src/main/kotlin/org/misarch/catalog/graphql/model/connection/base/BaseOrder.kt
@@ -13,9 +13,9 @@ import com.querydsl.core.types.OrderSpecifier
  */
 @GraphQLIgnore
 abstract class BaseOrder<T : BaseOrderField>(
-    @GraphQLDescription("The direction to order by")
+    @property:GraphQLDescription("The direction to order by")
     val direction: OrderDirection,
-    @GraphQLDescription("The field to order by")
+    @property:GraphQLDescription("The field to order by")
     val field: T
 ) {
 


### PR DESCRIPTION
Due to some interesting behavior, in some cases the `GraphQLDescription` was not added to the actual GraphQL schema.
This was caused by the default target of the annotation being the parameter and not the property.
To fix this bug once and for all, I fixed the annotation target to `property` everywhere (even though in some cases it might not be required, but I'm sick of this bug/behavior).
Also adds two actually missing descriptions.