### PR TITLE
make internalName only accessible to employees

### DIFF
--- a/src/main/kotlin/org/misarch/catalog/graphql/model/Product.kt
+++ b/src/main/kotlin/org/misarch/catalog/graphql/model/Product.kt
@@ -22,11 +22,17 @@ import java.util.concurrent.CompletableFuture
 @KeyDirective(fields = FieldSet("id"))
 class Product(
     id: UUID,
-    @property:GraphQLDescription("An internal name to identify the Product, not visible to customers.")
-    val internalName: String,
+    private val internalName: String,
     @property:GraphQLDescription("If true, the Product is visible to customers.")
-    val isPubliclyVisible: Boolean, private val defaultVariantId: UUID
+    val isPubliclyVisible: Boolean,
+    private val defaultVariantId: UUID
 ) : Node(id) {
+
+    @GraphQLDescription("An internal name to identify the Product, not visible to customers.")
+    fun internalName(dfe: DataFetchingEnvironment): String {
+        dfe.authorizedUser.checkIsEmployee()
+        return internalName
+    }
 
     @GraphQLDescription("The default variant of the product.")
     fun defaultVariant(


### PR DESCRIPTION
https://frontend.gropius.duckdns.org/components/79d21092-749a-481a-bacf-30a34f870fee/issues/946c51a3-2544-407d-b0ef-039ce9ecd5b4

DoD:
- [x] Requirements of the issue are met
- [x] Code has been reviewed
- [x] Code is documented
- [x] GraphQL related artefacts are documented